### PR TITLE
Ignore empty address line 2 in formattedAddress

### DIFF
--- a/index.js
+++ b/index.js
@@ -310,7 +310,7 @@ module.exports = {
     }
     
     var addressString = result.addressLine1;
-    if (result.hasOwnProperty('addressLine2')) {
+    if (result.hasOwnProperty('addressLine2') && result.addressLine2.length > 0) {
       addressString += ', ' + result.addressLine2;
     }
     if (addressString && result.hasOwnProperty("placeName") && result.hasOwnProperty("stateAbbreviation") && result.hasOwnProperty("zipCode")) {

--- a/test/test.js
+++ b/test/test.js
@@ -676,6 +676,21 @@ describe('#parseAddress', function() {
         expect(result).to.not.have.property("zipCodePlusFour");
     });
     
+    it('should return a formattedAddress field when a second address line is empty', function() {
+        var result = addresser.parseAddress("12939 Live Oak Street,, San Antonio, TX 78253");
+        expect(result.streetNumber).to.equal("12939");
+        expect(result.streetName).to.equal("Live Oak");
+        expect(result.streetSuffix).to.equal("St");
+        expect(result.addressLine1).to.equal("12939 Live Oak St");
+        expect(result.addressLine2).to.equal("");
+        expect(result.formattedAddress).to.equal("12939 Live Oak St, San Antonio, TX 78253");
+        expect(result.placeName).to.equal("San Antonio");
+        expect(result.stateAbbreviation).to.equal("TX");
+        expect(result.stateName).to.equal("Texas");
+        expect(result.zipCode).to.equal('78253');
+        expect(result).to.not.have.property("zipCodePlusFour");
+    });
+    
     it('should parse a simple Canadian Address without zip Code', function() {
         var result = addresser.parseAddress("123 Main St, Toronto, ON");
         expect(result.streetNumber).to.equal("123");


### PR DESCRIPTION
I think the following address `12939 Live Oak Street,, San Antonio, TX 78253` should return a formatted address like `12939 Live Oak St, San Antonio, TX 78253` rather than `12939 Live Oak St, , San Antonio, TX 78253`.

If a second address line is parsed and determined to be empty, I would prefer to ignore. What's your opinion?
