### PR TITLE
Updated Typescript Definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,11 +5,15 @@ declare module "addresser" {
 	export function cities(): IStateCities;
 
 	export interface IParsedAddress {
-		zipCode: string;
+		zipCode: string | undefined;
+		zipCodePlusFour: string | undefined;
+		formattedAddress: string | undefined;
 		stateAbbreviation: string;
 		stateName: string;
 		placeName: string;
 		addressLine1: string;
+		addressLine2: string | undefined;
+		streetDirection: string | undefined;
 		streetNumber: string;
 		streetSuffix: string;
 		streetName: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,15 +5,15 @@ declare module "addresser" {
 	export function cities(): IStateCities;
 
 	export interface IParsedAddress {
-		zipCode: string | undefined;
-		zipCodePlusFour: string | undefined;
-		formattedAddress: string | undefined;
+		zipCode: string;
+		zipCodePlusFour?: string;
+		formattedAddress?: string;
 		stateAbbreviation: string;
 		stateName: string;
 		placeName: string;
 		addressLine1: string;
-		addressLine2: string | undefined;
-		streetDirection: string | undefined;
+		addressLine2?: string;
+		streetDirection?: string;
 		streetNumber: string;
 		streetSuffix: string;
 		streetName: string;


### PR DESCRIPTION
I noticed that some of the optional fields were missing from your typescript definitions. This PR adds the correct (from what I could tell) types.