### PR TITLE
Correctly parse address1 ending in US Route number

### DIFF
--- a/index.js
+++ b/index.js
@@ -214,7 +214,8 @@ module.exports = {
         '( +(?:' + usStreetDirectionalString + ')\\b)?', 'i');
       var rePO = new RegExp('(P\\.?O\\.?|POST\\s+OFFICE)\\s+(BOX|DRAWER)\\s\\w+', 'i');
       var reAveLetter = new RegExp('\.\*\\b(ave.?|avenue)\.\*\\b[a-zA-Z]\\b', 'i');
-      var reNoSuffix = new RegExp('\\b\\d+[a-z]?\\s[a-zA-Z0-9_ ]+\\b', 'i');
+      var reNoSuffix = new RegExp("\\b\\d+[a-z]?\\s[a-zA-Z0-9_ -]+\\b", "i");
+
       if (streetString.match(reAveLetter)) {
         result.addressLine1 = streetString.match(reAveLetter)[0];
         streetString = streetString.replace(reAveLetter,"").trim(); // Carve off the first address line

--- a/test/test.js
+++ b/test/test.js
@@ -505,6 +505,20 @@ describe('#parseAddress', function() {
         expect(result).to.not.have.property("zipCode");        
         expect(result).to.not.have.property("zipCodePlusFour");
     });
+
+    it('should parse an address1 ending with a US Route', function() {
+        var result = addresser.parseAddress("737 US-42, Ashland, OH 44805");
+        expect(result.streetNumber).to.equal("737");
+        expect(result.streetName).to.equal("US-42");
+        expect(result).to.not.have.property('streetSuffix')
+        expect(result.addressLine1).to.equal("737 US-42");
+        expect(result).to.not.have.property('addressLine2')
+        expect(result.placeName).to.equal("Ashland");
+        expect(result.stateAbbreviation).to.equal("OH");
+        expect(result.stateName).to.equal("Ohio");
+        expect(result.zipCode).to.equal("44805")
+        expect(result).to.not.have.property("zipCodePlusFour");
+    });
     
     it('should parse FM number style road names', function() {
         var result = addresser.parseAddress("11434 W FM 471, San Antonio, TX");


### PR DESCRIPTION
Tweaks regex to prevent stripping ending route numbers (e.g `-42` from addresses on US Routes. Changes were tested for parity against a sample of 2MM addresses from our internal dataset.

```
> parseAddress('737 US-42, ASHLAND, OH 44805')

//output
{
  //missing the -42
  "formattedAddress": "737 US, Ashland, OH 44805",
  "addressLine1": "737 US",
  "streetNumber": "737",
  "id": "737-US,-Ashland,-OH-44805"

  "zipCode": "44805",
  "stateAbbreviation": "OH",
  "stateName": "Ohio",
  "placeName": "Ashland",
   "streetName": "US",
}
```