### PR TITLE
add run to street types

### DIFF
--- a/data/us-street-types.json
+++ b/data/us-street-types.json
@@ -417,6 +417,7 @@
     "rpds"       : "rpds",
     "rst"        : "rst",
     "rte"        : "rte",
+    "run"        : "run",
     "rvr"        : "riv",
     "row"        : "row",
     "shl"        : "shl",


### PR DESCRIPTION
Per [wikipedia](https://en.wikipedia.org/wiki/Street_suffix), a common street type.

<img width="1063" height="466" alt="Screenshot_2025-12-04_at_4_17_51 PM" src="https://github.com/user-attachments/assets/4b0091bc-18b0-4d91-8b74-f176b938d698" />

Thanks!